### PR TITLE
Search tenants either by owner email or username

### DIFF
--- a/tcms_github_marketplace/models.py
+++ b/tcms_github_marketplace/models.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2020 Alexander Todorov <atodorov@MrSenko.com>
+# Copyright (c) 2019-2021 Alexander Todorov <atodorov@MrSenko.com>
 
 # Licensed under the GPL 3.0: https://www.gnu.org/licenses/gpl-3.0.txt
 
@@ -29,6 +29,4 @@ class Purchase(models.Model):
         ]
 
     def __str__(self):
-        return "Purchase %s from %s on %s" % (self.action,
-                                              self.sender,
-                                              self.received_on.isoformat())
+        return f"Purchase {self.action} from {self.sender} on {self.received_on.isoformat()}"

--- a/tcms_github_marketplace/tests/test_views.py
+++ b/tcms_github_marketplace/tests/test_views.py
@@ -473,8 +473,7 @@ class CancelPlanTestCase(InstallTestCase):
             provider='github',
             uid='12345',
             extra_data={"access_token": "TEST-ME", "token_type": "bearer"})
-        cls.gh_revoke_url = '/applications/%s/tokens/TEST-ME' % \
-                            settings.SOCIAL_AUTH_GITHUB_KEY
+        cls.gh_revoke_url = f'/applications/{settings.SOCIAL_AUTH_GITHUB_KEY}/tokens/TEST-ME'
 
     def test_purchased_free_plan(self):
         # override so we don't execute it twice inside this class

--- a/tcms_github_marketplace/tests/test_views_createview.py
+++ b/tcms_github_marketplace/tests/test_views_createview.py
@@ -132,7 +132,7 @@ class CreateTenantTestCase(tcms_tenants.tests.LoggedInTestCase):
         # requires login
         self.assertRedirects(
             response,
-            reverse('tcms-login') + '?next=%s' % self.create_tenant_url)
+            reverse('tcms-login') + f'?next={self.create_tenant_url}')
 
     def test_visit_without_purchase(self):
         """
@@ -394,25 +394,22 @@ class CreateTenantTestCase(tcms_tenants.tests.LoggedInTestCase):
 
         self.assertContains(response, 'New tenant')
         self.assertContains(response, 'Private Tenant Warning')
-        self.assertContains(response, 'action="%s"' % self.create_tenant_url)
+        self.assertContains(response, f'action="{self.create_tenant_url}"')
         self.assertContains(response, 'Paid until')
         self.assertContains(response, 'Validation pattern: ^[a-z0-9]{1,63}$')
         self.assertContains(
             response,
             '<input type="hidden" name="paid_until"'
-            ' value="%s" id="id_paid_until">' %
-            expected_paid_until,
+            f' value="{expected_paid_until}" id="id_paid_until">',
             html=True)
         self.assertContains(
             response,
             'class="bootstrap-switch" name="publicly_readable" type="checkbox"')
         self.assertContains(response, 'Owner')
-        self.assertContains(response, "<label>%s</label>" %
-                            self.tester.username)
+        self.assertContains(response, f"<label>{self.tester.username}</label>")
 
         self.assertContains(response, 'Organization')
-        self.assertContains(response, "<label>%s</label>" %
-                            self.tester.username)
+        self.assertContains(response, f"<label>{self.tester.username}</label>")
 
     def test_visit_after_free_purchase(self):
         """

--- a/tcms_github_marketplace/utils.py
+++ b/tcms_github_marketplace/utils.py
@@ -62,7 +62,7 @@ def revoke_oauth_token(token):
                        'KiwiTCMS/Python', MainClass.DEFAULT_PER_PAGE,
                        True, None)
 
-    revoke_url = '/applications/%s/tokens/%s' % (settings.SOCIAL_AUTH_GITHUB_KEY, token)
+    revoke_url = f'/applications/{settings.SOCIAL_AUTH_GITHUB_KEY}/tokens/{token}'
     _headers, _data = gh_api.requestJsonAndCheck('DELETE', revoke_url)
 
 

--- a/tcms_github_marketplace/utils.py
+++ b/tcms_github_marketplace/utils.py
@@ -58,9 +58,9 @@ def revoke_oauth_token(token):
     gh_api = Requester(settings.SOCIAL_AUTH_GITHUB_KEY,
                        settings.SOCIAL_AUTH_GITHUB_SECRET,
                        None, MainClass.DEFAULT_BASE_URL,
-                       MainClass.DEFAULT_TIMEOUT, None, None,
+                       MainClass.DEFAULT_TIMEOUT,
                        'KiwiTCMS/Python', MainClass.DEFAULT_PER_PAGE,
-                       True, None)
+                       True, None, None)
 
     revoke_url = f'/applications/{settings.SOCIAL_AUTH_GITHUB_KEY}/tokens/{token}'
     _headers, _data = gh_api.requestJsonAndCheck('DELETE', revoke_url)

--- a/tcms_github_marketplace/views.py
+++ b/tcms_github_marketplace/views.py
@@ -7,6 +7,7 @@
 import json
 from datetime import datetime
 
+from django.db.models import Q
 from django.conf import settings
 from django.urls import reverse
 from django.http import HttpResponse, HttpResponseRedirect
@@ -163,7 +164,7 @@ class FastSpringHook(View):
             # recurring billing
             if event['type'] == 'subscription.charge.completed':
                 tenant = Tenant.objects.filter(
-                    owner__email=purchase.sender,
+                    Q(owner__email=purchase.sender) | Q(owner__username=purchase.sender),
                     paid_until__isnull=False,
                 ).exclude(schema_name='public').first()
                 if tenant:

--- a/tcms_github_marketplace/views.py
+++ b/tcms_github_marketplace/views.py
@@ -230,8 +230,7 @@ class Install(View):
             )
 
         raise NotImplementedError(
-            'Unsupported GitHub Marketplace action: "%s"' %
-            purchase.action)
+            f'Unsupported GitHub Marketplace action: "{purchase.action}"')
 
 
 @method_decorator(login_required, name='dispatch')


### PR DESCRIPTION
some tenant owners use the billing email as their username, while
changing the contact email in the Kiwi TCMS database. This will match
any of the two scenarios.