### PR TITLE
Configure product access for GitHub Marketplace purchases

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,9 @@
 Marketplace integrations for Kiwi TCMS
 ======================================
 
-.. image:: https://coveralls.io/repos/github/kiwitcms/github-marketplace/badge.svg?branch=master
-   :target: https://coveralls.io/github/kiwitcms/github-marketplace?branch=master
+.. image:: https://codecov.io/gh/kiwitcms/github-marketplace/branch/master/graph/badge.svg?token=NQKAQMJ8N8
+    :target: https://codecov.io/gh/kiwitcms/github-marketplace
+    :alt: Code coverage badge
 
 .. image:: https://pyup.io/repos/github/kiwitcms/github-marketplace/shield.svg
     :target: https://pyup.io/repos/github/kiwitcms/github-marketplace/

--- a/README.rst
+++ b/README.rst
@@ -29,14 +29,31 @@ Everyting that we do is open and that's why this piece of code is
 open source as well. You don't need this add-on in order to run Kiwi TCMS!
 
 
-Installation and configuration
-------------------------------
+Installation
+------------
 
     pip install kiwitcms-github-marketplace
 
-Then make sure ``KIWI_GITHUB_MARKETPLACE_SECRET`` and
-``KIWI_FASTSPRING_SECRET`` settings are configured as binary strings,
-e.g. ``b'secret'``.
+
+Configuration
+-------------
+
+Required settings:
+
+- ``KIWI_GITHUB_MARKETPLACE_SECRET`` - binary string
+- ``KIWI_FASTSPRING_SECRET`` - binary string
+- ``QUAY_IO_TOKEN`` - string
+
+
+Product configuration
+---------------------
+
+- Subscriptions on FastSpring use the SKU field to define access to private
+  docker repositories. The format is ``repo_name1+repo_name2``, where
+  ``https://quay.io/kiwitcms/<repo_name>`` exists
+- Plans on GitHub Marketplace use one of their bullet items to define access
+  to private docker repositories. Format is
+  ``Docker repositories: quay.io/kiwitcms/<repo1>, quay.io/kiwitcms/<repo2>``
 
 
 Changelog

--- a/tcms_github_marketplace/tests/test_fastspring_hook.py
+++ b/tcms_github_marketplace/tests/test_fastspring_hook.py
@@ -533,6 +533,7 @@ class FastSpringHookTestCase(tcms_tenants.tests.LoggedInTestCase):
             ).exists()
         )
 
+        # tmp_account calculates the actual robot name for mocking - currently not in use
         with docker.QuayIOAccount(self.tester.email) as tmp_account:
             with patch.object(
                 docker.QuayIOAccount,

--- a/tcms_github_marketplace/views.py
+++ b/tcms_github_marketplace/views.py
@@ -75,6 +75,21 @@ class PurchaseHook(View):
             return utils.cancel_plan(purchase)
 
         if purchase.action == "purchased":
+            # Configure product access if needed
+            for item in payload["marketplace_purchase"]["plan"]["bullets"]:
+                if "Docker repositories" in item:
+                    sku = (
+                        item.replace("Docker repositories:", "")
+                        .replace(" ", "")
+                        .replace("https://", "")
+                        .replace("quay.io/kiwitcms/", "")
+                        .replace(",", "+")
+                    )
+                    # create Robot account for Quay.io
+                    with docker.QuayIOAccount(purchase.sender) as account:
+                        account.create()
+                        utils.configure_product_access(account, sku)
+
             # recurring billing events don't redirect to Install URL
             # they only send a web hook
             tenant = (


### PR DESCRIPTION
GH Marketplace doesn't have a SKU field so the information is specified
in the last bullet item of the Marketplace plan.