### PR TITLE
Fix potentially uninitilized local variable

### DIFF
--- a/tcms_github_marketplace/quay/quay_session.py
+++ b/tcms_github_marketplace/quay/quay_session.py
@@ -127,6 +127,8 @@ class QuaySession(object):
         Returns:
             str: Full URL of the endpoint.
         """
+        schema = ""
+
         if self.api == "docker":
             schema = "{0}{1}/v2/{2}"
         elif self.api == "quay":


### PR DESCRIPTION
https://github.com/kiwitcms/github-marketplace/security/code-scanning/6 https://github.com/kiwitcms/github-marketplace/security/code-scanning/7

which isn't a real issue b/c the constructor of this class checks that the value of self.api is either "docker" or "quay" and raises an exception otherwise.

This commit should silence CodeQL though.