### PR TITLE
Allow edits to Tenant.extra_emails field

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-kiwitcms-tenants>=2.0
+kiwitcms-tenants>=2.8.3
 mailchimp3==3.0.21
 requests
 sqlparse>=0.5.0 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/tcms_github_marketplace/locale/en/LC_MESSAGES/django.po
+++ b/tcms_github_marketplace/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-02-23 21:39+0000\n"
+"POT-Creation-Date: 2024-05-01 18:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -22,105 +22,130 @@ msgstr ""
 msgid "Subscriptions"
 msgstr ""
 
-#: tcms_github_marketplace/templates/tcms_github_marketplace/subscription.html:11
+#: tcms_github_marketplace/templates/tcms_github_marketplace/email/exit_poll.txt:1
+msgid ""
+"Thank you for using Kiwi TCMS via a paid subscription.\n"
+"We're sorry to see you go but we'd like to know why so we can improve in the "
+"future!\n"
+"\n"
+"You can share your feedback at https://forms.gle/RJhFengbjN9C6wtUA\n"
+"\n"
+"Thank you!"
+msgstr ""
+
+#: tcms_github_marketplace/templates/tcms_github_marketplace/subscription.html:6
 msgid "Tenant subscriptions"
 msgstr ""
 
-#: tcms_github_marketplace/templates/tcms_github_marketplace/subscription.html:19
+#: tcms_github_marketplace/templates/tcms_github_marketplace/subscription.html:15
 msgid "You can access the following tenants"
 msgstr ""
 
-#: tcms_github_marketplace/templates/tcms_github_marketplace/subscription.html:24
+#: tcms_github_marketplace/templates/tcms_github_marketplace/subscription.html:20
 msgid "Tenant"
 msgstr ""
 
-#: tcms_github_marketplace/templates/tcms_github_marketplace/subscription.html:29
-#: tcms_github_marketplace/templates/tcms_tenants/override_new.html:15
+#: tcms_github_marketplace/templates/tcms_github_marketplace/subscription.html:25
+#: tcms_github_marketplace/templates/tcms_tenants/override_new.html:17
 msgid "Owner"
 msgstr ""
 
-#: tcms_github_marketplace/templates/tcms_github_marketplace/subscription.html:35
-#: tcms_github_marketplace/templates/tcms_github_marketplace/subscription.html:94
-#: tcms_github_marketplace/templates/tcms_tenants/override_new.html:28
+#: tcms_github_marketplace/templates/tcms_github_marketplace/subscription.html:31
+#: tcms_github_marketplace/templates/tcms_github_marketplace/subscription.html:90
+#: tcms_github_marketplace/templates/tcms_tenants/override_new.html:30
 msgid "Organization"
 msgstr ""
 
-#: tcms_github_marketplace/templates/tcms_github_marketplace/subscription.html:48
+#: tcms_github_marketplace/templates/tcms_github_marketplace/subscription.html:44
 msgid "Docker credentials"
 msgstr ""
 
-#: tcms_github_marketplace/templates/tcms_github_marketplace/subscription.html:53
+#: tcms_github_marketplace/templates/tcms_github_marketplace/subscription.html:49
 msgid "Username"
 msgstr ""
 
-#: tcms_github_marketplace/templates/tcms_github_marketplace/subscription.html:58
+#: tcms_github_marketplace/templates/tcms_github_marketplace/subscription.html:54
 msgid "Password"
 msgstr ""
 
-#: tcms_github_marketplace/templates/tcms_github_marketplace/subscription.html:65
+#: tcms_github_marketplace/templates/tcms_github_marketplace/subscription.html:61
 msgid "Private containers instructions"
 msgstr ""
 
-#: tcms_github_marketplace/templates/tcms_github_marketplace/subscription.html:79
+#: tcms_github_marketplace/templates/tcms_github_marketplace/subscription.html:75
 msgid "You own the following tenants"
 msgstr ""
 
-#: tcms_github_marketplace/templates/tcms_github_marketplace/subscription.html:101
-#: tcms_github_marketplace/templates/tcms_github_marketplace/subscription.html:102
+#: tcms_github_marketplace/templates/tcms_github_marketplace/subscription.html:97
+#: tcms_github_marketplace/templates/tcms_github_marketplace/subscription.html:98
 msgid "Price"
 msgstr ""
 
-#: tcms_github_marketplace/templates/tcms_github_marketplace/subscription.html:106
-#: tcms_github_marketplace/templates/tcms_github_marketplace/subscription.html:107
+#: tcms_github_marketplace/templates/tcms_github_marketplace/subscription.html:102
+#: tcms_github_marketplace/templates/tcms_github_marketplace/subscription.html:103
 msgid "Subscription type"
 msgstr ""
 
-#: tcms_github_marketplace/templates/tcms_github_marketplace/subscription.html:111
-#: tcms_github_marketplace/templates/tcms_github_marketplace/subscription.html:112
-#: tcms_github_marketplace/templates/tcms_tenants/override_new.html:6
+#: tcms_github_marketplace/templates/tcms_github_marketplace/subscription.html:107
+#: tcms_github_marketplace/templates/tcms_github_marketplace/subscription.html:108
+#: tcms_github_marketplace/templates/tcms_tenants/override_new.html:8
 msgid "Paid until"
 msgstr ""
 
-#: tcms_github_marketplace/templates/tcms_github_marketplace/subscription.html:118
+#: tcms_github_marketplace/templates/tcms_github_marketplace/subscription.html:114
 msgid "Cancel subscription"
 msgstr ""
 
-#: tcms_github_marketplace/templates/tcms_github_marketplace/subscription.html:120
+#: tcms_github_marketplace/templates/tcms_github_marketplace/subscription.html:116
 msgid "Cancel"
 msgstr ""
 
-#: tcms_github_marketplace/templates/tcms_github_marketplace/subscription.html:131
+#: tcms_github_marketplace/templates/tcms_github_marketplace/subscription.html:127
 msgid "You don't own any tenants"
 msgstr ""
 
-#: tcms_github_marketplace/templates/tcms_github_marketplace/subscription.html:135
+#: tcms_github_marketplace/templates/tcms_github_marketplace/subscription.html:131
 msgid "Subscribe via FastSpring"
 msgstr ""
 
-#: tcms_github_marketplace/templates/tcms_github_marketplace/subscription.html:151
+#: tcms_github_marketplace/templates/tcms_github_marketplace/subscription.html:147
 msgid "Transaction history"
 msgstr ""
 
-#: tcms_github_marketplace/templates/tcms_github_marketplace/subscription.html:173
-#: tcms_github_marketplace/templates/tcms_github_marketplace/subscription.html:174
+#: tcms_github_marketplace/templates/tcms_github_marketplace/subscription.html:169
+#: tcms_github_marketplace/templates/tcms_github_marketplace/subscription.html:170
 msgid "Sender"
 msgstr ""
 
-#: tcms_github_marketplace/templates/tcms_github_marketplace/subscription.html:178
-#: tcms_github_marketplace/templates/tcms_github_marketplace/subscription.html:179
+#: tcms_github_marketplace/templates/tcms_github_marketplace/subscription.html:174
+#: tcms_github_marketplace/templates/tcms_github_marketplace/subscription.html:175
 msgid "Vendor"
 msgstr ""
 
-#: tcms_github_marketplace/templates/tcms_github_marketplace/subscription.html:183
-#: tcms_github_marketplace/templates/tcms_github_marketplace/subscription.html:184
+#: tcms_github_marketplace/templates/tcms_github_marketplace/subscription.html:179
+#: tcms_github_marketplace/templates/tcms_github_marketplace/subscription.html:180
 msgid "Received on"
 msgstr ""
 
-#: tcms_github_marketplace/templates/tcms_tenants/override_new.html:42
+#: tcms_github_marketplace/templates/tcms_tenants/include/tenant_extra_emails.html:4
+msgid "Extra emails"
+msgstr ""
+
+#: tcms_github_marketplace/templates/tcms_tenants/include/tenant_extra_emails.html:14
+msgid ""
+"Kiwi TCMS will try to match recurring billing events against tenant.owner."
+"email + tenant.extra_emails"
+msgstr ""
+
+#: tcms_github_marketplace/templates/tcms_tenants/include/tenant_extra_emails.html:17
+msgid "Separate by comma (,), semi-colon (;) or white space ( )"
+msgstr ""
+
+#: tcms_github_marketplace/templates/tcms_tenants/override_new.html:44
 msgid "Private Tenant Warning"
 msgstr ""
 
-#: tcms_github_marketplace/templates/tcms_tenants/override_new.html:47
+#: tcms_github_marketplace/templates/tcms_tenants/override_new.html:49
 msgid ""
 "You are about to create a Private Tenant for Kiwi TCMS.\n"
 "It will take a few minutes until your DB schema is ready!\n"
@@ -132,10 +157,18 @@ msgid ""
 "<a href=\"mailto:kiwitcms@mrsenko.com\">kiwitcms@mrsenko.com</a> immediately!"
 msgstr ""
 
-#: tcms_github_marketplace/views.py:423
+#: tcms_github_marketplace/utils.py:95
+msgid "Kiwi TCMS Subscription Exit Poll"
+msgstr ""
+
+#: tcms_github_marketplace/views.py:567
+msgid "Kiwi TCMS subscription notification"
+msgstr ""
+
+#: tcms_github_marketplace/views.py:749
 msgid "mo"
 msgstr ""
 
-#: tcms_github_marketplace/views.py:426
+#: tcms_github_marketplace/views.py:752
 msgid "yr"
 msgstr ""

--- a/tcms_github_marketplace/templates/tcms_tenants/include/tenant_extra_emails.html
+++ b/tcms_github_marketplace/templates/tcms_tenants/include/tenant_extra_emails.html
@@ -1,0 +1,20 @@
+{% load i18n %}
+
+    <div class="form-group">
+        <label class="col-md-1 col-lg-1" for="id_extra_emails">{% trans "Extra emails" %}</label>
+        <div class="col-sm-11 col-md-8 col-lg-5 {% if form.extra_emails.errors %}has-error{% endif %}">
+            <input type="text" id="id_extra_emails" maxlength="{{ form.fields.extra_emails.max_length }}"
+                   placeholder="technical@example.bg; billing@example.bg"
+                   name="extra_emails" value="{{ form.extra_emails.value|default:'' }}"
+                   class="form-control"
+                   {% if form.extra_emails.field.disabled %}disabled{% endif %}>
+            {{ form.extra_emails.errors }}
+
+            <p class="help-block">
+                {% trans "Kiwi TCMS will try to match recurring billing events against tenant.owner.email + tenant.extra_emails" %}
+            </p>
+            <p class="help-block">
+                {% trans "Separate by comma (,), semi-colon (;) or white space ( )" %}
+            </p>
+        </div>
+    </div>

--- a/tcms_github_marketplace/templates/tcms_tenants/override_edit.html
+++ b/tcms_github_marketplace/templates/tcms_tenants/override_edit.html
@@ -1,0 +1,6 @@
+{% extends "tcms_tenants/new.html" %}
+{% load i18n %}
+
+{% block extra_contents %}
+    {% include 'tcms_tenants/include/tenant_extra_emails.html' %}
+{% endblock %}

--- a/tcms_github_marketplace/templates/tcms_tenants/override_new.html
+++ b/tcms_github_marketplace/templates/tcms_tenants/override_new.html
@@ -2,6 +2,8 @@
 {% load i18n %}
 
 {% block extra_contents %}
+    {% include 'tcms_tenants/include/tenant_extra_emails.html' %}
+
     <div class="form-group">
         <label class="col-md-1 col-lg-1">{% trans "Paid until" %}</label>
         <div class="col-sm-11 col-md-8 col-lg-5 {% if form.paid_until.errors %}has-error{% endif %}">

--- a/tcms_github_marketplace/tests/test_views_createview.py
+++ b/tcms_github_marketplace/tests/test_views_createview.py
@@ -434,6 +434,13 @@ class CreateTenantTestCase(tcms_tenants.tests.TenantGroupsTestCase):
             response,
             'class="bootstrap-switch" name="publicly_readable" type="checkbox"',
         )
+        self.assertContains(
+            response,
+            '<input type="text" id="id_extra_emails" maxlength="256" '
+            'placeholder="technical@example.bg; billing@example.bg" '
+            'name="extra_emails" value="" class="form-control">',
+            html=True,
+        )
         self.assertContains(response, "Owner")
         self.assertContains(response, f"<label>{self.tester.username}</label>")
 
@@ -605,6 +612,7 @@ class CreateTenantTestCase(tcms_tenants.tests.TenantGroupsTestCase):
                 "owner": self.tester.pk,
                 "organization": "",
                 "publicly_readable": False,
+                "extra_emails": "billing@example.org; admin@example.net",
                 "paid_until": timezone.now() + timedelta(days=30),
             },
         )
@@ -616,6 +624,7 @@ class CreateTenantTestCase(tcms_tenants.tests.TenantGroupsTestCase):
 
         tenant = tcms_tenants.models.Tenant.objects.get(schema_name="tinc")
         self.assertEqual(tenant.owner, self.tester)
+        self.assertEqual(tenant.extra_emails, "billing@example.org; admin@example.net")
         with tenant_context(tenant):
             self.assertTrue(
                 tenant.owner.tenant_groups.filter(name="Administrator").exists()

--- a/tcms_github_marketplace/tests/test_views_update_tenant.py
+++ b/tcms_github_marketplace/tests/test_views_update_tenant.py
@@ -1,0 +1,63 @@
+# Copyright (c) 2024 Alexander Todorov <atodorov@otb.bg>
+
+# Licensed under the GPL 3.0: https://www.gnu.org/licenses/gpl-3.0.txt
+# pylint: disable=too-many-ancestors
+
+from django.contrib.auth.models import Permission
+from django.urls import reverse
+
+import tcms_tenants.tests
+
+
+class UpdateTenantTestCase(tcms_tenants.tests.LoggedInTestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.edit_tenant_url = reverse("tcms_tenants:edit-tenant")
+        cls.create_tenant_url = reverse("github_marketplace_create_tenant")
+        cls.purchase_hook_url = reverse("github_marketplace_purchase_hook")
+
+        cls.change_tenant = Permission.objects.get(
+            content_type__app_label="tcms_tenants", codename="change_tenant"
+        )
+        cls.tester.user_permissions.add(cls.change_tenant)
+
+        # update owner so the currently logged user during test execution
+        # can edit the tenant
+        cls.tenant.owner = cls.tester
+        cls.tenant.save()
+
+    @classmethod
+    def use_existing_tenant(cls):
+        cls.setup_tenant(cls.tenant)
+
+    def test_editing_tenant_extra_emails_field_should_work(self):
+        self.assertIsNone(self.tenant.extra_emails)
+
+        # GET the Edit tenant page should display the extra_emails field
+        response = self.client.get(self.edit_tenant_url)
+        self.assertContains(
+            response,
+            '<input type="text" id="id_extra_emails" maxlength="256" '
+            'placeholder="technical@example.bg; billing@example.bg" '
+            'name="extra_emails" value="" class="form-control">',
+            html=True,
+        )
+
+        # send a POST request to update the values
+        response = self.client.post(
+            self.edit_tenant_url,
+            {
+                "name": "After Edits",
+                "owner": self.tester.pk,
+                "extra_emails": "billing@example.org; admin@example.net",
+            },
+        )
+        # should still redirect to the tenant which was created in the previous step
+        self.assertRedirects(response, "/")
+
+        self.tenant.refresh_from_db()
+        self.assertEqual(self.tenant.name, "After Edits")
+        self.assertEqual(
+            self.tenant.extra_emails, "billing@example.org; admin@example.net"
+        )


### PR DESCRIPTION
by overriding the HTML templates so we can expose this field

- Allowed when creating a new tenant
- Allowed when editing an existing tenant