### PR TITLE
Further adjust the query

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -64,7 +64,7 @@ Product configuration
 Changelog
 ---------
 
-v4.2.1 (21 Apr 2025)
+v4.2.2 (21 Apr 2025)
 ~~~~~~~~~~~~~~~~~~~~
 
 - Bug fix: update exclude filter for Tenant Subscriptions page to account for

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ def get_install_requires(path):
 
 setup(
     name="kiwitcms-github-marketplace",
-    version="4.2.1",
+    version="4.2.2",
     description="GitHub Marketplace integration for Kiwi TCMS",
     long_description=get_long_description(),
     author="Kiwi TCMS",

--- a/tcms_github_marketplace/views.py
+++ b/tcms_github_marketplace/views.py
@@ -773,7 +773,11 @@ class ViewSubscriptionPlan(UpdateView):
         which has the subscription field set! Note that some events,
         e.g. order.canceled may have this field set to None
         """
-        return self.get_queryset().exclude(subscription__contains="None").first()
+        return (
+            self.get_queryset()
+            .exclude(Q(subscription=None) | Q(subscription__contains="None"))
+            .first()
+        )
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)


### PR DESCRIPTION
to account for older records which haven't been converted to the new format and crash the view