### PR TITLE
Build & test with Python 3.12 and Django 6

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -141,6 +141,24 @@ jobs:
         run: |
           echo "${{ secrets.QUAY_PULL_TOKEN }}" | docker login -u="${{ secrets.QUAY_PULL_USERNAME }}" --password-stdin hub.kiwitcms.eu
 
+      - name: Build intermediary kiwitcms/version:16.0 image
+        env:
+          RUNTIME_BASE: registry.access.redhat.com/ubi10-minimal:latest
+        run: |
+          git clone https://github.com/kiwitcms/Kiwi
+          make -C Kiwi/ docker-image
+          docker tag pub.kiwitcms.eu/kiwitcms/kiwi:latest hub.kiwitcms.eu/kiwitcms/version:16.0
+
+      - name: Build intermediary kiwitcms/enterprise:latest image
+        env:
+          PKG_TOKEN: ${{ secrets.GEMFURY_PULL_TOKEN }}
+        run: |
+          git clone https://github.com/kiwitcms/enterprise
+          make -C enterprise/ docker-image
+          docker tag \
+              hub.kiwitcms.eu/kiwitcms/enterprise:16.0-mt-$(uname -m) \
+              hub.kiwitcms.eu/kiwitcms/enterprise:latest
+
       - name: Execute tests
         env:
           PKG_TOKEN: ${{ secrets.GEMFURY_PULL_TOKEN }}

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -142,6 +142,8 @@ jobs:
           echo "${{ secrets.QUAY_PULL_TOKEN }}" | docker login -u="${{ secrets.QUAY_PULL_USERNAME }}" --password-stdin hub.kiwitcms.eu
 
       - name: Execute tests
+        env:
+          PKG_TOKEN: ${{ secrets.GEMFURY_PULL_TOKEN }}
         run: |
           make test-via-docker
 

--- a/Dockerfile.testing
+++ b/Dockerfile.testing
@@ -1,4 +1,8 @@
 FROM hub.kiwitcms.eu/kiwitcms/enterprise
 
 COPY ./dist/*.whl /Kiwi/dist/
-RUN pip install --no-cache-dir --find-links /Kiwi/dist/ /Kiwi/dist/kiwitcms_github_marketplace*.whl
+ARG PKG_TOKEN
+RUN pip install --no-cache-dir --find-links /Kiwi/dist/ \
+    --index-url https://$PKG_TOKEN@pkg.kiwitcms.eu/pypi/ \
+    --extra-index-url https://pypi.org/simple/ \
+    /Kiwi/dist/kiwitcms_github_marketplace*.whl

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,10 @@ package:
 
 .PHONY: test-via-docker
 test-via-docker: package
-	docker build -f Dockerfile.testing -t kiwitcms/github-marketplace:latest .
+	test -n "$(PKG_TOKEN)" || exit 1
+	docker build -f Dockerfile.testing \
+	    --build-arg PKG_TOKEN=$(PKG_TOKEN) \
+	    -t kiwitcms/github-marketplace:latest .
 	docker images
 	test_project/sanity-check.sh
 

--- a/README.rst
+++ b/README.rst
@@ -65,6 +65,15 @@ Product configuration
 Changelog
 ---------
 
+v4.8.0 (17 Jun 2026)
+~~~~~~~~~~~~~~~~~~~~
+
+- Require minimum Python version 3.12
+- Build & test with Django >= 6
+- Update kiwitcms-tenants requirement from >=2.8.3 to >=4.5.0
+- Add ``django.contrib.postgres`` to ``INSTALLED_APPS``
+
+
 v4.7.0 (05 Jun 2026)
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 httplink==0.2.0
-kiwitcms-tenants>=2.8.3
+kiwitcms-tenants>=4.5.0
 mailchimp3==3.0.21
 requests
 sqlparse>=0.5.0 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ def get_install_requires(path):
 
 setup(
     name="kiwitcms-github-marketplace",
-    version="4.7.0",
+    version="4.8.0",
     description="GitHub Marketplace integration for Kiwi TCMS",
     long_description=get_long_description(),
     author="Kiwi TCMS",

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ setup(
     url="https://github.com/kiwitcms/github-marketplace/",
     license="AGPLv3+",
     install_requires=get_install_requires("requirements.txt"),
+    python_requires=">=3.12",
     packages=find_packages(exclude=["test_project*", "*.tests"]),
     zip_safe=False,
     include_package_data=True,
@@ -48,5 +49,6 @@ setup(
         "License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.12",
+        "Framework :: Django :: 6.0",
     ],
 )

--- a/tcms_settings_dir/marketplace.py
+++ b/tcms_settings_dir/marketplace.py
@@ -7,3 +7,6 @@
 
 if "tcms_github_marketplace.api" not in MODERNRPC_METHODS_MODULES:  # noqa: F821
     MODERNRPC_METHODS_MODULES.append("tcms_github_marketplace.api")  # noqa: F821
+
+if "django.contrib.postgres" not in INSTALLED_APPS:  # noqa: F821
+    INSTALLED_APPS.append("django.contrib.postgres")  # noqa: F821

--- a/test_project/settings.py
+++ b/test_project/settings.py
@@ -116,6 +116,5 @@ GEMFURY_API_TOKEN = os.getenv("GEMFURY_API_TOKEN")
 TEST_RUNNER = os.environ.get("DJANGO_TEST_RUNNER", "django.test.runner.DiscoverRunner")
 
 # only for testing
-ALLOWED_HOSTS.append(  # noqa: F821 pylint: disable=used-before-assignment
-    "testing.example.bg"
-)
+# pylint: disable=possibly-used-before-assignment
+ALLOWED_HOSTS.append("testing.example.bg")  # noqa: F821


### PR DESCRIPTION
Build & test against a minimum of Python 3.12 and Django 6 (latest kiwitcms/Kiwi from the master branch, which now pins Django 6.0).

- Declare `python_requires=">=3.12"`
- Add `Framework :: Django :: 6.0` classifier