### PR TITLE
Migrate to django-modern-rpc v2 decorator pattern

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -141,6 +141,24 @@ jobs:
         run: |
           echo "${{ secrets.QUAY_PULL_TOKEN }}" | docker login -u="${{ secrets.QUAY_PULL_USERNAME }}" --password-stdin hub.kiwitcms.eu
 
+      - name: Build intermediary kiwitcms/version:16.1 image
+        env:
+          RUNTIME_BASE: registry.access.redhat.com/ubi10-minimal:latest
+        run: |
+          git clone https://github.com/kiwitcms/Kiwi
+          make -C Kiwi/ docker-image
+          docker tag pub.kiwitcms.eu/kiwitcms/kiwi:latest hub.kiwitcms.eu/kiwitcms/version:16.1
+
+      - name: Build intermediary kiwitcms/enterprise:latest image
+        env:
+          PKG_TOKEN: ${{ secrets.GEMFURY_PULL_TOKEN }}
+        run: |
+          git clone https://github.com/kiwitcms/enterprise
+          make -C enterprise/ docker-image
+          docker tag \
+              hub.kiwitcms.eu/kiwitcms/enterprise:16.1-mt-$(uname -m) \
+              hub.kiwitcms.eu/kiwitcms/enterprise:latest
+
       - name: Execute tests
         env:
           PKG_TOKEN: ${{ secrets.GEMFURY_PULL_TOKEN }}

--- a/README.rst
+++ b/README.rst
@@ -65,6 +65,13 @@ Product configuration
 Changelog
 ---------
 
+v4.9.0 (18 Jul 2026)
+~~~~~~~~~~~~~~~~~~~~
+
+- Refactor API methods for compatibility with django-modern-rpc v2
+- Add JSON-RPC test for GitOps.allow() API method
+
+
 v4.8.1 (23 Jun 2026)
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ def get_install_requires(path):
 
 setup(
     name="kiwitcms-github-marketplace",
-    version="4.8.1",
+    version="4.9.0",
     description="GitHub Marketplace integration for Kiwi TCMS",
     long_description=get_long_description(),
     author="Kiwi TCMS",

--- a/tcms_github_marketplace/api.py
+++ b/tcms_github_marketplace/api.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Alexander Todorov <atodorov@otb.bg>
+# Copyright (c) 2024-2026 Alexander Todorov <atodorov@otb.bg>
 #
 # Licensed under GNU Affero General Public License v3 or later (AGPLv3+)
 # https://www.gnu.org/licenses/agpl-3.0.html
@@ -7,13 +7,16 @@
 
 from django.core.cache import cache
 from django.utils import timezone
-from modernrpc.core import rpc_method
 
+from tcms.rpc.views import rpc_method
 from tcms_github_marketplace import utils
 from tcms_github_marketplace.models import Purchase
 
 
-@rpc_method(name="GitOps.allow")
+@rpc_method(
+    name="GitOps.allow",
+    auth=None,
+)
 def gitops_allow(repo_url):  # pylint: disable=missing-api-permissions-required
     """
     .. function:: RPC GitOps.allow(repo_url)


### PR DESCRIPTION
Import `rpc_method` from `tcms.rpc.views` which wraps both XML-RPC and JSON-RPC handlers. Use `auth=None` explicitly since `GitOps.allow` is a public endpoint. No `**kwargs`/`REQUEST_KEY` usage, so no `context_target` needed.

Update copyright year to 2024-2026.